### PR TITLE
Use opencc conversion for traditional input

### DIFF
--- a/rpm/fanchuan-keyboard.spec
+++ b/rpm/fanchuan-keyboard.spec
@@ -1,5 +1,5 @@
 Name: fanchuan-keyboard
-Version: 0.0.1
+Version: 0.1.0
 Release: 1%{?dist}
 Summary: A Chinese keyboard suite for Sailfish OS
 License: LGPL2.1

--- a/rpm/fanchuan-keyboard.spec
+++ b/rpm/fanchuan-keyboard.spec
@@ -38,5 +38,6 @@ rm -rf %{buildroot}
 /usr/share/maliit/plugins/com/jolla/layouts/zh_cnt_pinyin.qml
 /usr/share/maliit/plugins/com/jolla/layouts/fanchuan/Xt9CpMultiInputHandler.qml
 /usr/share/maliit/plugins/com/jolla/layouts/fanchuan/SetGlyphKey.qml
+/usr/share/maliit/plugins/com/jolla/layouts/fanchuan/TopBarGlyphKey.qml
 
 %changelog

--- a/src/fanchuan/TopBarGlyphKey.qml
+++ b/src/fanchuan/TopBarGlyphKey.qml
@@ -6,14 +6,16 @@ import "../.."
 
 Item {
     id: switchCharKey
+    property bool leftAlign: false
     height: Theme.itemSizeSmall
-    width: height * 0.7
+    width: height * 0.9
     Rectangle {
         id: switchbg
+        width: parent.width * 0.8
+        height: parent.height * 0.8
         anchors {
-            fill: parent
-            topMargin: Theme.paddingMedium
-            bottomMargin: Theme.paddingMedium
+            left: leftAlign ? parent.left : undefined
+            verticalCenter: parent.verticalCenter
         }
         color: switchButton.pressed ? Theme.highlightBackgroundColor : Theme.primaryColor
         opacity: switchButton.pressed ? 0.6 : 0.3
@@ -39,6 +41,10 @@ Item {
         id: switchKeyText
         height: parent.height
         width: parent.width
+        anchors {
+            verticalCenter: switchbg.verticalCenter
+            horizontalCenter: switchbg.horizontalCenter
+        }
         text: (layoutRow.layout.inputMode === "traditional" ? "繁" : "简")
         maximumLineCount: 1
         color: switchButton.pressed ? Theme.highlightColor : Theme.primaryColor

--- a/src/fanchuan/TopBarGlyphKey.qml
+++ b/src/fanchuan/TopBarGlyphKey.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.0
+import com.jolla.keyboard 1.0
+import Sailfish.Silica 1.0
+import ".."
+import "../.."
+
+Item {
+    id: switchCharKey
+    height: Theme.itemSizeSmall
+    width: height * 0.7
+    Rectangle {
+        id: switchbg
+        anchors {
+            fill: parent
+            topMargin: Theme.paddingMedium
+            bottomMargin: Theme.paddingMedium
+        }
+        color: switchButton.pressed ? Theme.highlightBackgroundColor : Theme.primaryColor
+        opacity: switchButton.pressed ? 0.6 : 0.3
+        radius: geometry.keyRadius
+
+        MouseArea {
+            id: switchButton
+            anchors.fill: parent
+
+            onClicked: {
+                if (layoutRow.layout.inputMode === "simplified") {
+                    layoutRow.layout.inputMode = "traditional"
+                } else if (layoutRow.layout.inputMode === "traditional") {
+                    layoutRow.layout.inputMode = "simplified"
+                }
+                // disables model reset
+                glyphSwap = true
+            }
+        }
+    }
+
+    Label {
+        id: switchKeyText
+        height: parent.height
+        width: parent.width
+        text: (layoutRow.layout.inputMode === "traditional" ? "繁" : "简")
+        maximumLineCount: 1
+        color: switchButton.pressed ? Theme.highlightColor : Theme.primaryColor
+        font {
+            pixelSize: Theme.fontSizeSmall
+            family: Theme.fontFamily
+        }
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+        z: 100
+    }
+}

--- a/src/fanchuan/TopBarGlyphKey.qml
+++ b/src/fanchuan/TopBarGlyphKey.qml
@@ -45,7 +45,7 @@ Item {
             verticalCenter: switchbg.verticalCenter
             horizontalCenter: switchbg.horizontalCenter
         }
-        text: (layoutRow.layout.inputMode === "traditional" ? "繁" : "简")
+        text: (layoutRow.layout.inputMode === "traditional" ? "简" : "繁")
         maximumLineCount: 1
         color: switchButton.pressed ? Theme.highlightColor : Theme.primaryColor
         font {

--- a/src/fanchuan/Xt9CpMultiInputHandler.qml
+++ b/src/fanchuan/Xt9CpMultiInputHandler.qml
@@ -94,7 +94,11 @@ InputHandler {
 
                     model: composingEnabled ? xt9CpModel : 0
                     orientation: ListView.Horizontal
-                    width: parent.width
+                    clip: true
+                    anchors {
+                        left: parent.left
+                        right: switchGlyphKey.left
+                    }
                     height: parent.height
                     boundsBehavior: ((!keyboard.expandedPaste && Clipboard.hasText) || handler.hasMore)
                                     ? Flickable.DragOverBounds : Flickable.StopAtBounds
@@ -171,10 +175,12 @@ InputHandler {
                 }
 
                 TopBarGlyphKey {
+                    id: switchGlyphKey
+                    leftAlign: true
                     anchors {
                         right: parent.right
                         verticalCenter: parent.verticalCenter
-                        rightMargin: Theme.paddingMedium
+                        rightMargin: Theme.paddingTiny
                     }
                 }
             }
@@ -297,10 +303,11 @@ InputHandler {
                 }
 
                 TopBarGlyphKey {
+                    width: Theme.itemSizeSmall
+                    height: width * 0.9
                     anchors {
                         right: parent.right
                         bottom: parent.bottom
-                        rightMargin: Theme.paddingMedium
                     }
                 }
             }


### PR DESCRIPTION
Adds a nice traditional/simplified toggle switch on the top bar and uses opencc to convert from simplified to traditional for better text prediction support.